### PR TITLE
Setup for cross-platform development and support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = [ "robert.w.gries@gmail.com" ]
 crate-type = ["staticlib"]
 
 [dependencies]
+compiler_builtins = { git = "https://github.com/rust-lang-nursery/compiler-builtins" }
 rlibc = "1.0.0"
 spin = "0.3.4"
 volatile = "0.1.0"

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,30 @@
 arch ?= x86
 target ?= i386
 system ?= linux
+build ?= debug
+
+# Flags
+CFLAGS := --target=$(target)-unknown-none-elf -ffreestanding
+ASFLAGS := -masm=intel
+LDFLAGS := -n -nostdlib --gc-sections -melf_$(target)
+
+# Rust target
+rust_arch := $(target)
+ifeq ($(rust_arch),i386)
+	rust_arch := i686
+else
+	CFLAGS += -mno-red-zone
+endif
+
+# Debug flags
+ifeq ($(build),debug)
+	CFLAGS += -g
+	LDFLAGS += -g
+endif
 
 # kernel binaries
 kernel := build/rxinu-$(arch)-$(target).bin
 iso := build/rxinu-$(arch)-$(target).iso
-
-# Rust target
-rust_arch := $(target)
-ifeq ($(target),i386)
-	rust_arch := i686
-endif
 
 # Rust Binaries
 
@@ -33,12 +47,6 @@ ASM_SRC := $(wildcard src/arch/$(arch)/*.S) \
 
 # Object files
 ASM_OBJ := $(patsubst src/arch/$(arch)/%.S, build/arch/$(arch)/%.o, $(ASM_SRC))
-
-# Flags
-CFLAGS := --target=$(target)-pc-none-elf
-CFLAGS += -fno-builtin -ffunction-sections -fwrapv
-ASFLAGS := -fno-integrated-as -masm=intel
-LDFLAGS := -n --gc-sections -melf_$(target)
 
 .PHONY: all cargo clean run iso
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build ?= debug
 # Flags
 CFLAGS := --target=$(target)-unknown-none-elf -ffreestanding
 ASFLAGS := -masm=intel
-LDFLAGS := -nostdlib --gc-sections -melf_$(target)
+LDFLAGS := -n -nostdlib --gc-sections -melf_$(target)
 
 # Rust target
 rust_arch := $(target)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Target and build files
 arch ?= x86
 target ?= i386
+system ?= linux
 
 # kernel binaries
 kernel := build/rxinu-$(arch)-$(target).bin
@@ -13,7 +14,15 @@ ifeq ($(target),i386)
 endif
 
 # Rust Binaries
-rust_target ?= $(rust_arch)-unknown-linux-gnu
+
+# Target
+ifeq ($(system),linux)
+	rust_target ?= $(rust_arch)-unknown-linux-gnu
+endif
+ifeq ($(system),apple)
+	rust_target ?= $(rust_arch)-apple-darwin
+endif
+
 rust_os := target/$(rust_target)/debug/librxinu.a
 
 # Source files

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,17 @@
 # Target and build files
 arch ?= x86
 target ?= i386
-system ?= linux
 build ?= debug
 
 # Flags
 CFLAGS := --target=$(target)-unknown-none-elf -ffreestanding
 ASFLAGS := -masm=intel
-LDFLAGS := -n -nostdlib --gc-sections -melf_$(target)
+LDFLAGS := -n --gc-sections -melf_$(target)
 
 # Rust target
 rust_arch := $(target)
 ifeq ($(rust_arch),i386)
 	rust_arch := i686
-else
-	CFLAGS += -mno-red-zone
 endif
 
 # Debug flags
@@ -28,15 +25,7 @@ kernel := build/rxinu-$(arch)-$(target).bin
 iso := build/rxinu-$(arch)-$(target).iso
 
 # Rust Binaries
-
-# Target
-ifeq ($(system),linux)
-	rust_target ?= $(rust_arch)-unknown-linux-gnu
-endif
-ifeq ($(system),apple)
-	rust_target ?= $(rust_arch)-apple-darwin
-endif
-
+rust_target ?= $(rust_arch)-unknown-linux-gnu
 rust_os := target/$(rust_target)/debug/librxinu.a
 
 # Source files

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build ?= debug
 # Flags
 CFLAGS := --target=$(target)-unknown-none-elf -ffreestanding
 ASFLAGS := -masm=intel
-LDFLAGS := -n -nostdlib --gc-sections -melf_$(target)
+LDFLAGS := -nostdlib --gc-sections -melf_$(target)
 
 # Rust target
 rust_arch := $(target)

--- a/src/arch/x86/error.S
+++ b/src/arch/x86/error.S
@@ -6,5 +6,5 @@ error:
   mov dword ptr [0xb8000], 0x4f524f45
   mov dword ptr [0xb8004], 0x4f3a4f52
   mov dword ptr [0xb8008], 0x4f204f20
-  mov byte      [0xb800a], al
+  mov byte  ptr [0xb800a], al
   hlt

--- a/src/arch/x86/linker.ld
+++ b/src/arch/x86/linker.ld
@@ -13,31 +13,31 @@ SECTIONS
 	/* First put the multiboot header, as it is required to be put very early
 	   early in the image or the bootloader won't recognize the file format.
 	   Next we'll put the .text section. */
-	.text :
+	.text BLOCK(4K) : ALIGN(4K)
 	{
 		KEEP(*(.multiboot_header))
 		*(.text .text.*)
 	}
 
 	/* Read-only data. */
-	.rodata :
+	.rodata BLOCK(4K) : ALIGN(4K)
 	{
 		*(.rodata .rodata.*)
 	}
 
-        .data.rel.ro :
-        {
-                *(.data.rel.ro.local*) *(.data.rel.ro .data.rel.ro.*)
-        }
-
 	/* Read-write data (initialized) */
-	.data :
+	.data BLOCK(4K) : ALIGN(4K)
 	{
-		*(.data)
+		*(.data .data.*)
+	}
+
+	.data.rel.ro BLOCK(4K) : ALIGN(4K)
+	{
+		*(.data.rel.ro.local*) *(.data.rel.ro .data.rel.ro.*)
 	}
 
 	/* Read-write data (uninitialized) and stack */
-	.bss :
+	.bss BLOCK(4K) : ALIGN(4K)
 	{
 		*(COMMON)
 		*(.bss)

--- a/src/arch/x86/linker.ld
+++ b/src/arch/x86/linker.ld
@@ -13,26 +13,31 @@ SECTIONS
 	/* First put the multiboot header, as it is required to be put very early
 	   early in the image or the bootloader won't recognize the file format.
 	   Next we'll put the .text section. */
-	.text BLOCK(4K) : ALIGN(4K)
+	.text :
 	{
 		KEEP(*(.multiboot_header))
-		*(.text)
+		*(.text .text.*)
 	}
 
 	/* Read-only data. */
-	.rodata BLOCK(4K) : ALIGN(4K)
+	.rodata :
 	{
-		*(.rodata)
+		*(.rodata .rodata.*)
 	}
 
+        .data.rel.ro :
+        {
+                *(.data.rel.ro.local*) *(.data.rel.ro .data.rel.ro.*)
+        }
+
 	/* Read-write data (initialized) */
-	.data BLOCK(4K) : ALIGN(4K)
+	.data :
 	{
 		*(.data)
 	}
 
 	/* Read-write data (uninitialized) and stack */
-	.bss BLOCK(4K) : ALIGN(4K)
+	.bss :
 	{
 		*(COMMON)
 		*(.bss)

--- a/src/arch/x86/startup-common.S
+++ b/src/arch/x86/startup-common.S
@@ -39,7 +39,7 @@ startup:
   # To set up a stack, we set the esp register to point to the top of our
   # stack (as it grows downwards on x86 systems). This is necessarily done
   # in assembly as languages such as C cannot function without a stack.
-  mov esp, offset stack_top
+  lea esp, stack_top
 
   call check_multiboot
   call check_cpuid

--- a/src/arch/x86/x86_64/long_mode_start.S
+++ b/src/arch/x86/x86_64/long_mode_start.S
@@ -1,4 +1,5 @@
 .intel_syntax noprefix
+.code64
 
 .extern rust_main
 

--- a/src/arch/x86/x86_64/paging.S
+++ b/src/arch/x86/x86_64/paging.S
@@ -17,12 +17,12 @@ p2_table:
 .type setup_page_tables, @function
 setup_page_tables:
   # map first P4 entry to P3 table
-  mov eax, offset p3_table
+  lea eax, p3_table
   or eax, 0b11 # present + writable
   mov [p4_table], eax
 
   # map first P3 entry to P2 table
-  mov eax, offset p2_table
+  lea eax, p2_table
   or eax, 0b11 # present + writable
   mov [p3_table], eax
 

--- a/src/arch/x86/x86_64/start.S
+++ b/src/arch/x86/x86_64/start.S
@@ -15,8 +15,11 @@ _start:
   call enable_paging
 
 flush_gdt:
+  lea eax, complete_flush
+  push dword ptr 0x08
+  push eax
   lgdt [gdtr]
-  jmp 0x08:complete_flush
+  retf
 
 complete_flush:
   mov eax, 0x10

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
 #![feature(unique)]
 #![no_std]
 
+#![feature(compiler_builtins_lib)]
+extern crate compiler_builtins;
+
 extern crate rlibc;
 extern crate spin;
 extern crate volatile;
@@ -20,7 +23,8 @@ pub extern fn rust_main() {
 }
 
 #[lang = "eh_personality"] extern fn eh_personality() {}
-#[lang = "panic_fmt"] extern fn panic_fmt() -> ! {loop{}}
+
+#[lang = "panic_fmt"] #[no_mangle] extern fn panic_fmt() -> ! {loop{}}
 
 #[allow(non_snake_case)]
 #[no_mangle]


### PR DESCRIPTION
* Use clang's integrated assembler for easier cross-platform compilation of assembly
* Trim Makefile flags
* Fix linker issue where `_umod` and `_udiv` could not be found
  * Solution: use `compiler_builtins` crate
* Fix linker issue: `undefined reference to rust_begin_unwind`
  * Solution: add `#[no_mangle]` before `panic_fmt`
  * Relevant Discussion: rust-lang/rust#38281