### PR TITLE
Enable Travis CI and rustfmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,21 @@ cache: cargo
 rust:
   - nightly
 env:
-  - target=i386
-  - target=x86_64
+  - ['target=i386', 'TARGET=i686-unknown-linux-gnu', 'COMPILER=clang-3.8']
+  - ['target=x86_64', 'TARGET=x86_64-unknown-linux-gnu', 'COMPILER=clang-3.8']
+addons:
+  apt:
+    sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8']
+    packages: ['clang-3.8']
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y clang qemu xorriso
+  - curl https://sh.rustup.rs -sSf | sh
 before_script:
+  - rustup default nightly
+  - rustup target add $TARGET
   - export PATH="$PATH:$HOME/.cargo/bin"
   - which rustfmt || cargo install rustfmt
-  - rustup target add i686-unknown-linux-gnu
-  - rustup target add x86_64-unknown-linux-gnu
 script:
   - cargo fmt -- --write-mode=diff
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ before_install:
   - curl https://sh.rustup.rs -sSf | bash -s -- -y
   - sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.8 100
 before_script:
-  - ~/.cargo/rustup install nightly
-  - ~/.cargo/rustup default nightly
-  - ~/.cargo/rustup target add $TARGET
+  - ~/.cargo/bin/rustup install nightly
+  - ~/.cargo/bin/rustup default nightly
+  - ~/.cargo/bin/rustup target add $TARGET
   - export PATH="$PATH:$HOME/.cargo/bin"
   - which rustfmt || cargo install rustfmt
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,9 @@ addons:
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y clang qemu xorriso
-  - curl https://sh.rustup.rs -sSf | sh
+  - curl https://sh.rustup.rs -sSf | bash -s -- -y
 before_script:
+  - rustup install nightly
   - rustup default nightly
   - rustup target add $TARGET
   - export PATH="$PATH:$HOME/.cargo/bin"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,17 @@ language: rust
 cache: cargo
 rust:
   - nightly
+env:
+  - target=i386
+  - target=x86_64
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y clang qemu xorriso
 before_script:
   - export PATH="$PATH:$HOME/.cargo/bin"
   - which rustfmt || cargo install rustfmt
+  - rustup target add i686-unknown-linux-gnu
+  - rustup target add x86_64-unknown-linux-gnu
 script:
   - cargo fmt -- --write-mode=diff
-  - make clean; make
-  - make clean; make target=x86_64
-matrix:
-  include:
-    - env: TARGET=i686-unknown-linux-gnu
-    - env: TARGET=x86_64-unknown-linux-gnu
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,13 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y qemu xorriso
   - curl https://sh.rustup.rs -sSf | bash -s -- -y
-  - sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.8 100
 before_script:
-  - ~/.cargo/bin/rustup install nightly
-  - ~/.cargo/bin/rustup default nightly
-  - ~/.cargo/bin/rustup target add $TARGET || true
+  - sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.8 100
+  - export CARGO="$HOME/.cargo/bin/cargo"
   - export PATH="$PATH:$HOME/.cargo/bin"
+  - rustup install nightly
+  - rustup default nightly
+  - rustup target add $TARGET || true
   - which rustfmt || cargo install rustfmt
 script:
   - cargo fmt -- --write-mode=diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 before_script:
   - ~/.cargo/bin/rustup install nightly
   - ~/.cargo/bin/rustup default nightly
-  - ~/.cargo/bin/rustup target add $TARGET
+  - ~/.cargo/bin/rustup target add $TARGET || true
   - export PATH="$PATH:$HOME/.cargo/bin"
   - which rustfmt || cargo install rustfmt
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,13 @@ addons:
     packages: ['clang-3.8']
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y clang qemu xorriso
+  - sudo apt-get install -y qemu xorriso
   - curl https://sh.rustup.rs -sSf | bash -s -- -y
+  - sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.8 100
 before_script:
-  - rustup install nightly
-  - rustup default nightly
-  - rustup target add $TARGET
+  - ~/.cargo/rustup install nightly
+  - ~/.cargo/rustup default nightly
+  - ~/.cargo/rustup target add $TARGET
   - export PATH="$PATH:$HOME/.cargo/bin"
   - which rustfmt || cargo install rustfmt
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: rust
 cache: cargo
-rust:
-  - nightly
 env:
-  - ['target=i386', 'TARGET=i686-unknown-linux-gnu', 'COMPILER=clang-3.8']
-  - ['target=x86_64', 'TARGET=x86_64-unknown-linux-gnu', 'COMPILER=clang-3.8']
+  - ['target=i386', 'TARGET=i686-unknown-linux-gnu', 'ASM=clang-3.8']
+  - ['target=x86_64', 'TARGET=x86_64-unknown-linux-gnu', 'ASM=clang-3.8']
 addons:
   apt:
     sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8']
@@ -14,9 +12,7 @@ before_install:
   - sudo apt-get install -y qemu xorriso
   - curl https://sh.rustup.rs -sSf | bash -s -- -y
 before_script:
-  - sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.8 100
-  - export CARGO="$HOME/.cargo/bin/cargo"
-  - export PATH="$PATH:$HOME/.cargo/bin"
+  - export PATH="$HOME/.cargo/bin:$PATH"
   - rustup install nightly
   - rustup default nightly
   - rustup target add $TARGET || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: rust
+cache: cargo
+rust:
+  - nightly
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y clang qemu xorriso
+before_script:
+  - export PATH="$PATH:$HOME/.cargo/bin"
+  - which rustfmt || cargo install rustfmt
+script:
+  - cargo fmt -- --write-mode=diff
+  - make clean; make
+  - make clean; make target=x86_64

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,7 @@ script:
   - cargo fmt -- --write-mode=diff
   - make clean; make
   - make clean; make target=x86_64
+matrix:
+  include:
+    - env: TARGET=i686-unknown-linux-gnu
+    - env: TARGET=x86_64-unknown-linux-gnu

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+# Tools
+CARGO ?= cargo
+ASM ?= clang
+LD ?= ld
+
 # Target and build files
 arch ?= x86
 target ?= i386
@@ -42,11 +47,11 @@ ASM_OBJ := $(patsubst src/arch/$(arch)/%.S, build/arch/$(arch)/%.o, $(ASM_SRC))
 all: $(kernel)
 
 cargo:
-	@cargo build --target $(rust_target)
+	@$(CARGO) build --target $(rust_target)
 
 clean:
 	@rm -rf build
-	@cargo clean
+	@$(CARGO) clean
 
 run: $(iso)
 	@qemu-system-x86_64 -cdrom $(iso)
@@ -61,12 +66,12 @@ $(iso): $(kernel) $(grub_cfg)
 	@grub-mkrescue -o $(iso) build/isofiles 2> /dev/null
 	@rm -rf build/isofiles
 
-$(kernel):  cargo $(rust_os) $(ASM_OBJ) $(linker_script)
+$(kernel):  $(CARGO) $(rust_os) $(ASM_OBJ) $(linker_script)
 	@echo "Building $(kernel)"
-	@ld $(LDFLAGS) -T $(linker_script) -o $(kernel) $(ASM_OBJ) $(rust_os)
+	@$(LD) $(LDFLAGS) -T $(linker_script) -o $(kernel) $(ASM_OBJ) $(rust_os)
 
 # compile architecture specific files
 build/arch/$(arch)/%.o: src/arch/$(arch)/%.S
 	@mkdir -p $(shell dirname $@)
 	@echo "  Assembling $<"
-	@clang $(ASFLAGS) $(CFLAGS) -c $< -o $@
+	@$(ASM) $(ASFLAGS) $(CFLAGS) -c $< -o $@

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,20 +14,25 @@ extern crate volatile;
 mod vga_buffer;
 
 #[no_mangle]
-pub extern fn rust_main() {
+pub extern "C" fn rust_main() {
     vga_buffer::clear_screen();
     for i in 0..100 {
         println!("Hello World{} {}", "!", i);
     }
-    loop{}
+    loop {}
 }
 
-#[lang = "eh_personality"] extern fn eh_personality() {}
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
 
-#[lang = "panic_fmt"] #[no_mangle] extern fn panic_fmt() -> ! {loop{}}
+#[lang = "panic_fmt"]
+#[no_mangle]
+extern "C" fn panic_fmt() -> ! {
+    loop {}
+}
 
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn _Unwind_Resume() -> ! {
-        loop {}
+    loop {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub extern "C" fn rust_main() {
 }
 
 #[lang = "eh_personality"]
+#[no_mangle]
 extern "C" fn eh_personality() {}
 
 #[lang = "panic_fmt"]

--- a/src/vga_buffer/color.rs
+++ b/src/vga_buffer/color.rs
@@ -2,22 +2,22 @@
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum Color {
-    Black      = 0,
-    Blue       = 1,
-    Green      = 2,
-    Cyan       = 3,
-    Red        = 4,
-    Magenta    = 5,
-    Brown      = 6,
-    LightGray  = 7,
-    DarkGray   = 8,
-    LightBlue  = 9,
+    Black = 0,
+    Blue = 1,
+    Green = 2,
+    Cyan = 3,
+    Red = 4,
+    Magenta = 5,
+    Brown = 6,
+    LightGray = 7,
+    DarkGray = 8,
+    LightBlue = 9,
     LightGreen = 10,
-    LightCyan  = 11,
-    LightRed   = 12,
-    Pink       = 13,
-    Yellow     = 14,
-    White      = 15,
+    LightCyan = 11,
+    LightRed = 12,
+    Pink = 13,
+    Yellow = 14,
+    White = 15,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/vga_buffer/writer.rs
+++ b/src/vga_buffer/writer.rs
@@ -32,7 +32,7 @@ impl Writer {
     }
 
     fn buffer(&mut self) -> &mut buffer::Buffer {
-        unsafe{ self.buffer.get_mut() }
+        unsafe { self.buffer.get_mut() }
     }
 
     fn new_line(&mut self) {
@@ -43,7 +43,7 @@ impl Writer {
                 buffer.chars[row - 1][col].write(character);
             }
         }
-        self.clear_row(buffer::MAX_HEIGHT-1);
+        self.clear_row(buffer::MAX_HEIGHT - 1);
         self.column_position = 0;
     }
 
@@ -62,7 +62,7 @@ impl Writer {
 impl ::core::fmt::Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
         for byte in s.as_bytes() {
-          self.write_byte(byte)
+            self.write_byte(byte)
         }
 
         Ok(())


### PR DESCRIPTION
Pushes to the repo and Pull Requests now trigger a Travis CI build which does the following:

1.  Install the latest nightly rust compiler
2.  Run [`rustfmt`](https://github.com/rust-lang-nursery/rustfmt) to see if the code adheres to rust style guidelines
3.  Build the kernel for i686 and x86_64 architectures.