### PR TITLE
Add docker support, fix travis, and clean up Readme

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.dockerignore
+.git
+README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ env:
 before_script:
   - rustup component add rust-src
   - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-  - (test -x $HOME/.cargo/bin/rustfmt || cargo install rustfmt-nightly)
   - (test -x $HOME/.cargo/bin/xargo || cargo install xargo)
+  - rustup run nightly cargo install rustfmt-nightly --force
   - cargo install-update -a
 
 addons:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:jessie
+MAINTAINER Rob Gries <robert.w.gries@gmail.com>
+
+RUN apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        build-essential \
+        nasm \
+        grub-common \
+        grub-pc-bin \
+        xorriso \
+        curl \
+        git;
+ 
+RUN useradd --create-home --shell /bin/bash rxinu
+USER rxinu
+WORKDIR /home/rxinu
+ENTRYPOINT ["/bin/bash"]
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y;
+
+RUN export PATH=$PATH:$HOME/.cargo/bin; \
+    rustup component add rust-src; \
+    cargo install xargo;

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update; \
         grub-pc-bin \
         xorriso \
         curl \
+        qemu \
         git;
  
 RUN useradd --create-home --shell /bin/bash rxinu
@@ -19,6 +20,13 @@ ENTRYPOINT ["/bin/bash"]
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y;
 
-RUN export PATH=$PATH:$HOME/.cargo/bin; \
-    rustup component add rust-src; \
-    cargo install xargo;
+RUN export PATH="$PATH:/$HOME/.cargo/bin" && \
+    rustup update nightly-${NIGHTLY_DATE} && \
+    rustup override add nightly-${NIGHTLY_DATE} && \
+    rustup component add rust-src && \
+    cargo install xargo
+
+RUN git clone https://github.com/robert-w-gries/rxinu.git
+
+ENV PATH="$PATH:/home/rxinu/.cargo/bin"
+WORKDIR /home/rxinu/rxinu

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ endif
 CFLAGS := --target=$(target)-unknown-none-elf -ffreestanding
 ASFLAGS := $(asm_target)
 LDFLAGS := -n --gc-sections -melf_$(ld_target)
-QEMUFLAGS := -nographic -serial telnet:127.0.0.1:4444,server
+#QEMUFLAGS := -nographic -serial telnet:127.0.0.1:4444,server
+QEMUFLAGS := -nographic
 CARGOFLAGS :=
 
 ifdef FEATURES

--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,10 @@ debug: $(iso)
 	@qemu-system-x86_64 $(QEMUFLAGS) -cdrom $(iso) -d int -s -S
 
 docker_build:
-	@docker build -t rxinu-os .
+	@docker build -t $(docker_image) .
 
 docker_run:
-	@docker run -it --rm -v $(pwd) $(docker_image)
+	@docker run -it --rm $(docker_image)
 
 gdb: $(kernel)
 	@$(GDB) "$(kernel)" -ex "target remote :1234"

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ rust_target ?= $(rust_arch)-rxinu
 rust_os := target/$(rust_target)/debug/librxinu.a
 
 # Docker
-docker_image ?= rxinu-os
+docker_image ?= robgries/rxinu-os
+tag ?= v0.1
 
 # Source files
 linker_script := src/arch/$(arch)/asm/linker.ld
@@ -77,10 +78,10 @@ debug: $(iso)
 	@qemu-system-x86_64 $(QEMUFLAGS) -cdrom $(iso) -d int -s -S
 
 docker_build:
-	@docker build -t $(docker_image) .
+	@docker build -t $(docker_image):$(tag) .
 
 docker_run:
-	@docker run -it --rm $(docker_image)
+	@docker run -it --rm $(docker_image):$(tag)
 
 gdb: $(kernel)
 	@$(GDB) "$(kernel)" -ex "target remote :1234"

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ endif
 CFLAGS := --target=$(target)-unknown-none-elf -ffreestanding
 ASFLAGS := $(asm_target)
 LDFLAGS := -n --gc-sections -melf_$(ld_target)
-#QEMUFLAGS := -nographic -serial telnet:127.0.0.1:4444,server
 QEMUFLAGS := -nographic
 CARGOFLAGS :=
 

--- a/README.md
+++ b/README.md
@@ -4,25 +4,26 @@
 Rust implementation of [Xinu](https://github.com/xinu-os/xinu), based on the [excellent blog written by Philipp Oppermann](https://os.phil-opp.com/)
 ## Dependencies
   
-### Quick Run
+### Quick Run (Docker)
+
+Clone this repo then run the following:
 
 ```bash
-sudo apt-get docker
-docker build -t rxinu-os .
-docker run --iter
-make run -it --rm -v $(pwd) rxinu-os
+sudo apt-get docker make
+make docker_build
+make docker_run
+make run # Inside of docker linux container
 ```
 
-### Install Dependencies
+### Build dependencies
 
 ```bash
 sudo apt-get install binutils clang curl grub nasm qemu xorriso -y
 curl https://sh.rustup.rs -sSf | sh
-source $HOME/.cargo/env
-# add $HOME/.cargo/bin to PATH env variable
+export PATH="${PATH}:$HOME/.cargo/bin"
 rustup install nightly
 rustup default nightly
-cargo install xargo --vers 0.3.8
+cargo install xargo
 rustup component add rust-src
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Rust implementation of [Xinu](https://github.com/xinu-os/xinu), based on the [ex
 Clone this repo then run the following:
 
 ```bash
-sudo apt-get install docker.io make # use 'docker' package for non-Ubuntu distros
+sudo apt-get install make
+wget -qO- https://get.docker.com/ | sh
+# Fedora: sudo systemctl start docker
 sudo make docker_build
 sudo make docker_run
 make run # Inside of docker linux container

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Rust implementation of [Xinu](https://github.com/xinu-os/xinu), based on the [ex
 Clone this repo then run the following:
 
 ```bash
-sudo apt-get install docker.io make # use 'docker' repo for non-Ubuntu distros
+sudo apt-get install docker.io make # use 'docker' package for non-Ubuntu distros
 sudo make docker_build
 sudo make docker_run
 make run # Inside of docker linux container
@@ -20,7 +20,7 @@ make run # Inside of docker linux container
 
 ```bash
 sudo apt-get install binutils clang curl grub nasm qemu xorriso -y
-curl https://sh.rustup.rs -sSf | sh
+curl https://sh.rustup.rs -sSf | sh -s -- -y
 export PATH="${PATH}:$HOME/.cargo/bin"
 rustup install nightly
 rustup default nightly
@@ -28,7 +28,14 @@ cargo install xargo
 rustup component add rust-src
 ```
 
-* Note: installing the `gcc-devel` apt repository was required to run `cargo install xargo`
+#### Distro Notes
+
+* Fedora
+  * `grub2` package was already installed
+  * `make run` fails due to wrong GRUB_MKRESCUE
+    * Use `make run GRUB_MKRESCUE=grub2-mkrescue` or `export GRUB_MKRESCUE=grub2-mkrescue`
+* OpenSUSE
+  * installing the `gcc-devel` apt repository was required to run `cargo install xargo`
 
 ### Required
 

--- a/README.md
+++ b/README.md
@@ -2,20 +2,21 @@
 
 # rxinu
 Rust implementation of [Xinu](https://github.com/xinu-os/xinu), based on the [excellent blog written by Philipp Oppermann](https://os.phil-opp.com/)
-## Dependencies
-  
-### Quick Run (Docker)
+
+## Quick Run (Docker)
 
 Clone this repo then run the following:
 
 ```bash
-sudo apt-get docker make
-make docker_build
-make docker_run
+sudo apt-get install docker.io make # use 'docker' repo for non-Ubuntu distros
+sudo make docker_build
+sudo make docker_run
 make run # Inside of docker linux container
 ```
 
-### Build dependencies
+## Dependencies
+
+### Quick Installation
 
 ```bash
 sudo apt-get install binutils clang curl grub nasm qemu xorriso -y

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ make run # Inside of docker linux container
 
 ## Dependencies
 
-### Quick Installation
+### Installation
 
 ```bash
 sudo apt-get install binutils clang curl grub nasm qemu xorriso -y
@@ -38,31 +38,6 @@ rustup component add rust-src
     * Use `make run GRUB_MKRESCUE=grub2-mkrescue` or `export GRUB_MKRESCUE=grub2-mkrescue`
 * OpenSUSE
   * installing the `gcc-devel` apt repository was required to run `cargo install xargo`
-
-### Required
-
-* cargo
-  * Rust package tool
-* rustup
-  * Rust toolchain manager
-  * Used for managing nightly rust
-* nasm
-  * Least painful assembler available. Supports 32 bit and 64 bit output
-
-### Optional
-
-* binutils
-* lld
-  * [`lld`](http://lld.llvm.org/) can replace `ld` if desired
-  * As of `4.0`, lld does not seem to support the `--nmagic` flag
-    * TODO: Get `lld` to link the kernel
-* qemu
-  * Used in Makefile for testing the kernel
-* grub
-  * Used to build iso file, which is necessary to test x86_64 kernel with `qemu`
-  * `xorriso` package is required dependency for building iso file
-    * Note: `xorriso` is only available in `libisoburn` for some distros
-  * Note: some distributions, such as OpenSUSE, require `grub2-mkrescue` instead of `grub-mkrescue`
 
 ## Compilation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@
 Rust implementation of [Xinu](https://github.com/xinu-os/xinu), based on the [excellent blog written by Philipp Oppermann](https://os.phil-opp.com/)
 ## Dependencies
   
-### Quick Start
+### Quick Run
+
+```bash
+sudo apt-get docker
+docker build -t rxinu-os .
+docker run --iter
+make run -it --rm -v $(pwd) rxinu-os
+```
+
+### Install Dependencies
+
 ```bash
 sudo apt-get install binutils clang curl grub nasm qemu xorriso -y
 curl https://sh.rustup.rs -sSf | sh


### PR DESCRIPTION
* `make docker_build` - builds local docker image
* `make docker_run` - runs local docker image or docker image hosted on [Docker Cloud](https://cloud.docker.com/app/robgries/repository/docker/robgries/rxinu-os/general)
* Travis needs to force install `rustfmt-nightly` after updating toolchain, otherwise it hits an error: [rustfmt: error while loading shared libraries: libsyntax-8cb7fde7ccb56910.so: cannot open shared object file: No such file or directory](https://travis-ci.org/robert-w-gries/rxinu/jobs/305631188#L523)
* Update stale installation/running info and update with notes on installing for different distributions
* Remove section that describes dependencies.  This will be superseded by #25 