### PR TITLE
Various scheduling enhancements and fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: rust
 rust:
   - nightly
-cache: cargo
+cache:
+  directories:
+    - $HOME/.cargo
 
 env:
   - ['target=i686', 'FEATURES="vga"']
@@ -23,5 +25,4 @@ addons:
 
 script:
   - cargo fmt -- --write-mode=diff
-  - make clean
   - make

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,16 @@ pub extern "C" fn created_process() {
     kprintln!("\nYou can now type...");
 }
 
+pub extern "C" fn cycle_process_a() {
+    kprint!(".");
+    syscall::create(cycle_process_b, String::from("cycle_process_b"));
+}
+
+pub extern "C" fn cycle_process_b() {
+    kprint!(".");
+    syscall::create(cycle_process_a, String::from("cycle_process_a"));
+}
+
 #[cfg(not(test))]
 #[lang = "eh_personality"]
 #[no_mangle]
@@ -108,7 +118,7 @@ pub extern "C" fn _Unwind_Resume() -> ! {
 }
 
 const HEAP_START: usize = 0o_000_001_000_000_0000;
-const HEAP_SIZE: usize = 500 * 1024; // 500 KB
+const HEAP_SIZE: usize = 100 * 1024 * 1024; // 100 MB
 
 use linked_list_allocator::LockedHeap;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub extern "C" fn _Unwind_Resume() -> ! {
 }
 
 const HEAP_START: usize = 0o_000_001_000_000_0000;
-const HEAP_SIZE: usize = 100 * 1024 * 1024; // 100 MB
+const HEAP_SIZE: usize = 500 * 1024; // 500 KB
 
 use linked_list_allocator::LockedHeap;
 

--- a/src/scheduling/cooperative_scheduler.rs
+++ b/src/scheduling/cooperative_scheduler.rs
@@ -31,10 +31,13 @@ impl DoesScheduling for CoopScheduler {
         let proc_stack_pointer: usize =
             stack.as_ptr() as usize + (proc_top * mem::size_of::<usize>());
 
+        use alloc::boxed::Box;
+        let self_ptr: Box<&DoesScheduling> = Box::new(self);
+
         let stack_values: Vec<usize> = vec![
             new_proc as usize,
             process::process_ret as usize,
-            self as *const Scheduler as usize,
+            Box::into_raw(self_ptr) as usize,
         ];
 
         for (i, val) in stack_values.iter().enumerate() {

--- a/src/scheduling/process.rs
+++ b/src/scheduling/process.rs
@@ -96,10 +96,13 @@ impl Process {
 /// The parent scheduler object will always be on the stack
 #[naked]
 pub unsafe extern "C" fn process_ret() {
-    use scheduling::{DoesScheduling, Scheduler};
+    use alloc::boxed::Box;
+    use scheduling::DoesScheduling;
 
-    let scheduler: &mut Scheduler;
-    asm!("pop $0" : "=r"(scheduler) : : "memory" : "intel", "volatile");
+    let scheduler_ptr: *mut &DoesScheduling;
+    asm!("pop $0" : "=r"(scheduler_ptr) : : "memory" : "intel", "volatile");
+
+    let scheduler = Box::from_raw(scheduler_ptr);
 
     let curr_id: ProcessId = scheduler.getid();
     scheduler.kill(curr_id);


### PR DESCRIPTION
This is a follow-up to #33 that aims to stabilize the scheduling code and make various quality of life improvements to the module.

## Reference counting in process list

Fixes #36 

The processes in the process list should be reference counted. [We need to guarantee that data shared between context switches will not be destroyed.](https://doc.rust-lang.org/book/first-edition/choosing-your-guarantees.html#guarantees).

This issue manifested while running process cycles where current process, `process_a`, creates `process_b` and `process_b` creates `process_a`.  We would randomly hit a page fault while trying to access the process list.  The issue was that the reference in the process list was randomly destroyed.  We need to explicitly tell the compiler that the process list contains data that will live long at runtime.

We'll use `Arc` instead of `Rc` because the references will also need to be safely shared across different CPUs when APIC is supported.

## Use generic trait object for dynamic dispatch in `process_ret`

Our first stab at dynamic dispatch in the `process_ret` function assumed that the scheduler will always be a `CoopScheduler`.  Since we know our scheduler will always implement `kill`, we should use the more general `DoesScheduling` trait object to call the kill method.  Now, we can truly use any scheduler object in the kernel to create and kill processes properly.