### PR TITLE
Restore interrupts to previous status instead of enabling global interrupts

### DIFF
--- a/src/arch/x86/console.rs
+++ b/src/arch/x86/console.rs
@@ -8,10 +8,15 @@ use device::uart_16550::COM1 as console;
 use device::vga::VGA as console;
 
 #[macro_export]
+/// Ensure lock are kept safe while printing
 macro_rules! kprint {
     ($($arg:tt)*) => ({
-            use core::fmt::Write;
-            let _ = write!($crate::arch::x86::console::CONSOLE.lock(), $($arg)*);
+            use arch::interrupts;
+
+            interrupts::disable_then_restore(|| {
+                use core::fmt::Write;
+                let _ = write!($crate::arch::x86::console::CONSOLE.lock(), $($arg)*);
+            });
     });
 }
 

--- a/src/arch/x86/device.rs
+++ b/src/arch/x86/device.rs
@@ -1,4 +1,4 @@
-use device::{pic_8259, ps2_controller_8042, uart_16550, pit};
+use device::{pit, pic_8259, ps2_controller_8042, uart_16550};
 
 pub fn init() {
     pic_8259::init();

--- a/src/arch/x86/interrupts/exception/mod.rs
+++ b/src/arch/x86/interrupts/exception/mod.rs
@@ -17,7 +17,10 @@ macro_rules! exception {
             kprintln!("\n{:#?}\n{:#?}",
                       stack_frame,
                       $desc);
-            $func
+            use arch::interrupts;
+            interrupts::disable_then_restore(|| {
+                $func
+            });
         }
     };
     ($e:ident, $desc:expr, $err_type:ty, $func:block) => {
@@ -26,7 +29,10 @@ macro_rules! exception {
             kprintln!("\n{:#?}\n{:#?}",
                       stack_frame,
                       $desc);
-            $func
+            use arch::interrupts;
+            interrupts::disable_then_restore(|| {
+                $func
+            });
         }
         #[cfg(target_arch = "x86_64")]
         pub extern "x86-interrupt" fn $e(stack_frame: &mut ErrorStack,
@@ -36,7 +42,10 @@ macro_rules! exception {
                       error_code,
                       stack_frame,
                       $desc);
-            $func
+            use arch::interrupts;
+            interrupts::disable_then_restore(|| {
+                $func
+            });
         }
     };
 }

--- a/src/arch/x86/interrupts/irq.rs
+++ b/src/arch/x86/interrupts/irq.rs
@@ -4,7 +4,7 @@ use device::pic_8259 as pic;
 use device::uart_16550 as serial;
 use device::pit::PIT_TICKS;
 use core::sync::atomic::Ordering;
-use scheduling::{SCHEDULER, DoesScheduling};
+use scheduling::{DoesScheduling, SCHEDULER};
 
 #[allow(dead_code)]
 fn trigger(irq: u8) {
@@ -21,7 +21,7 @@ pub extern "x86-interrupt" fn timer(_stack_frame: &mut ExceptionStack) {
     use arch::x86::interrupts;
 
     pic::MASTER.lock().ack();
-    
+
     //This counter variable is updated every time an timer interrupt occurs. The timer is set to
     //interrupt every 2ms, so this means a reschedule will occur if 20ms have passed.
     if PIT_TICKS.fetch_add(1, Ordering::SeqCst) >= 10 {

--- a/src/arch/x86/interrupts/irq.rs
+++ b/src/arch/x86/interrupts/irq.rs
@@ -29,7 +29,7 @@ pub extern "x86-interrupt" fn timer(_stack_frame: &mut ExceptionStack) {
 
         //Find another process to run.
         unsafe {
-            interrupts::disable_interrupts_then(|| {
+            interrupts::disable_then_restore(|| {
                 SCHEDULER.resched();
             })
         };

--- a/src/arch/x86/interrupts/mod.rs
+++ b/src/arch/x86/interrupts/mod.rs
@@ -1,23 +1,67 @@
+use device::pic_8259::{MASTER, SLAVE};
+use syscall::io::Io;
+
 pub mod exception;
 pub mod irq;
 pub mod syscall;
 
 pub const DOUBLE_FAULT_IST_INDEX: usize = 0;
 
-/// Disable interrupts, execute code uninterrupted, re-enable interrupts
-pub fn disable_interrupts_then<F, T>(uninterrupted_fn: F) -> T
+/// Disable interrupts, execute code uninterrupted, restore original interrupts
+pub fn disable_then_restore<F, T>(uninterrupted_fn: F) -> T
 where
     F: FnOnce() -> T,
 {
+    let saved_masks: (u8, u8) = disable();
+    let result: T = uninterrupted_fn();
+    restore(saved_masks);
+    result
+}
+
+/// Disable interrupts then return tuple of previous state for PIC1 and PIC2
+pub fn disable() -> (u8, u8) {
     unsafe {
         ::x86::shared::irq::disable();
     }
-    let result: T = uninterrupted_fn();
+
+    let saved_mask1 = MASTER.lock().data.read();
+    let saved_mask2 = SLAVE.lock().data.read();
+
+    MASTER.lock().data.write(0xff);
+    SLAVE.lock().data.write(0xff);
+
+    (saved_mask1, saved_mask2)
+}
+
+/// Enable all interrupts
+pub fn enable() {
+    unsafe {
+        ::x86::shared::irq::disable();
+    }
+
+    // Clear all masks from interrupt line so that all interrupts fire
+    MASTER.lock().data.write(0);
+    SLAVE.lock().data.write(0);
+
     unsafe {
         ::x86::shared::irq::enable();
     }
+}
 
-    result
+/// Enable interrupts, restoring the previously set masks
+pub fn restore(saved_masks: (u8, u8)) {
+    unsafe {
+        ::x86::shared::irq::disable();
+    }
+
+    let (saved_mask1, saved_mask2) = saved_masks;
+
+    MASTER.lock().data.write(saved_mask1);
+    SLAVE.lock().data.write(saved_mask2);
+
+    unsafe {
+        ::x86::shared::irq::enable();
+    }
 }
 
 #[cfg(test)]

--- a/src/arch/x86/mod.rs
+++ b/src/arch/x86/mod.rs
@@ -14,10 +14,8 @@ pub fn init(multiboot_information_address: usize) {
 
     gdt::init(&mut memory_controller);
 
-    interrupts::disable_interrupts_then(|| {
-        idt::init();
-        device::init();
-    });
+    idt::init();
+    device::init();
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/src/device/pic_8259.rs
+++ b/src/device/pic_8259.rs
@@ -20,8 +20,8 @@ pub fn init() {
         wait_port.write(0);
     };
 
-    //let saved_mask1 = MASTER.lock().data.read();
-    //let saved_mask2 = SLAVE.lock().data.read();
+    let saved_mask1 = MASTER.lock().data.read();
+    let saved_mask2 = SLAVE.lock().data.read();
 
     // Start initialization
     let init_value: u8 = (ICW1::INIT as u8) + (ICW1::ICW4_NOT_NEEDED as u8);
@@ -41,10 +41,8 @@ pub fn init() {
     write_then_wait(SLAVE.lock().data, ICW4::MODE_8086 as u8);
 
     // Restore saved masks
-    //write_then_wait(MASTER.lock().data, 0x0);
-    //write_then_wait(SLAVE.lock().data, 0x0);
-    //write_then_wait(MASTER.lock().data, saved_mask1);
-    //write_then_wait(SLAVE.lock().data, saved_mask2);
+    write_then_wait(MASTER.lock().data, saved_mask1);
+    write_then_wait(SLAVE.lock().data, saved_mask2);
 
     kprintln!("[ OK ] PIC Driver");
 }

--- a/src/device/pit.rs
+++ b/src/device/pit.rs
@@ -7,14 +7,14 @@ use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
 const PIT_SET: u8 = 0x36;
 static DIVISOR: u16 = 2685;
 
-pub static PIT: Mutex<[Port<u8>; 2]> = Mutex::new(unsafe {
+pub static PIT: Mutex<[Port<u8>; 2]> = Mutex::new(
     [
         // Command register.
         Port::new(0x43),
         // Channel 0.
         Port::new(0x40),
     ]
-});
+);
 
 pub fn init() {
     PIT.lock()[0].write(PIT_SET);

--- a/src/device/pit.rs
+++ b/src/device/pit.rs
@@ -7,14 +7,12 @@ use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
 const PIT_SET: u8 = 0x36;
 static DIVISOR: u16 = 2685;
 
-pub static PIT: Mutex<[Port<u8>; 2]> = Mutex::new(
-    [
-        // Command register.
-        Port::new(0x43),
-        // Channel 0.
-        Port::new(0x40),
-    ]
-);
+pub static PIT: Mutex<[Port<u8>; 2]> = Mutex::new([
+    // Command register.
+    Port::new(0x43),
+    // Channel 0.
+    Port::new(0x40),
+]);
 
 pub fn init() {
     PIT.lock()[0].write(PIT_SET);

--- a/src/device/pit.rs
+++ b/src/device/pit.rs
@@ -7,12 +7,14 @@ use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
 const PIT_SET: u8 = 0x36;
 static DIVISOR: u16 = 2685;
 
-pub static PIT: Mutex<[Port<u8>; 2]> = Mutex::new(unsafe {[
-    // Command register.
-    Port::new(0x43),
-    // Channel 0.
-    Port::new(0x40),
-]});
+pub static PIT: Mutex<[Port<u8>; 2]> = Mutex::new(unsafe {
+    [
+        // Command register.
+        Port::new(0x43),
+        // Channel 0.
+        Port::new(0x40),
+    ]
+});
 
 pub fn init() {
     PIT.lock()[0].write(PIT_SET);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,12 +43,16 @@ use alloc::String;
 #[no_mangle]
 /// Entry point for rust code
 pub extern "C" fn rust_main(multiboot_information_address: usize) {
-    arch::init(multiboot_information_address);
-    kprintln!("\nIt did not crash!");
+    arch::interrupts::disable();
+    {
+        arch::init(multiboot_information_address);
+        kprintln!("\nIt did not crash!");
 
-    unsafe {
-        HEAP_ALLOCATOR.lock().init(HEAP_START, HEAP_SIZE);
+        unsafe {
+            HEAP_ALLOCATOR.lock().init(HEAP_START, HEAP_SIZE);
+        }
     }
+    arch::interrupts::enable();
 
     kprintln!("\nHEAP START = 0x{:x}", HEAP_START);
     kprintln!("HEAP END = 0x{:x}\n", HEAP_START + HEAP_SIZE);

--- a/src/scheduling/cooperative_scheduler.rs
+++ b/src/scheduling/cooperative_scheduler.rs
@@ -95,14 +95,14 @@ impl DoesScheduling for CoopScheduler {
     }
 
     /// Safety: This method will deadlock if any scheduling locks are still held
-    unsafe fn resched(&self) { 
+    unsafe fn resched(&self) {
         // Ensure lock to ready list is not held.
         {
             //skip expensive locks if possible.
             if self.ready_list.read().is_empty() {
                 return;
             }
-        } 
+        }
 
         // TODO: Investigate less hacky way of context switching without deadlocking
         let mut prev_ptr = 0 as *mut Process;

--- a/src/scheduling/cooperative_scheduler.rs
+++ b/src/scheduling/cooperative_scheduler.rs
@@ -6,7 +6,6 @@ use scheduling::{DoesScheduling, Process, ProcessId, ProcessList, State, INIT_ST
 use scheduling::process;
 use spin::RwLock;
 use syscall::error::Error;
-use device::pit::PIT_TICKS;
 
 pub type Scheduler = CoopScheduler;
 

--- a/src/scheduling/cooperative_scheduler.rs
+++ b/src/scheduling/cooperative_scheduler.rs
@@ -81,7 +81,7 @@ impl DoesScheduling for CoopScheduler {
                 .write();
 
             proc_lock.set_state(State::Free);
-            drop(&mut proc_lock.kstack);
+            proc_lock.kstack = None;
             drop(&mut proc_lock.name);
         }
 

--- a/src/syscall/process.rs
+++ b/src/syscall/process.rs
@@ -5,7 +5,7 @@ use scheduling::{DoesScheduling, ProcessId, SCHEDULER};
 pub fn create(new_proc: extern "C" fn(), name: String) -> ProcessId {
     use arch::interrupts;
 
-    interrupts::disable_interrupts_then(|| -> ProcessId {
+    interrupts::disable_then_restore(|| -> ProcessId {
         let pid = SCHEDULER
             .create(new_proc, name)
             .expect("Could not create new process!");


### PR DESCRIPTION
### `disable_then_restore`

Previously, the `disable_interrupts_then` function would globally disable interrupts, run some code, then it would globally enable interrupts.  This worked well for the initial use case of disabling interrupts before initializing the PIC.

However, we ran into an issue where nested `disable_interrupts_then` calls would enable interrupts globally in places where we didn't expect it.  The behavior I actually wanted was as follows:

1. Disable interrupts globally
2. Run critical section of kernel
3. Restore interrupts to previous state before `step 1`

### Minor Changes

There were some minor changes involving compiler warnings and travis.  Also, it was determined that using `drop(&process.kstack)` would actually leak data, so we switch back to `process.kstack = None` in our `Scheduler.kill()` method.