### PR TITLE
Fix deadlocks in keyboard irq and avoid future deadlocks in irq handlers

### DIFF
--- a/src/arch/x86/interrupts/irq.rs
+++ b/src/arch/x86/interrupts/irq.rs
@@ -1,3 +1,4 @@
+use arch::x86::interrupts;
 use arch::x86::interrupts::exception::ExceptionStack;
 use device::{ps2_controller_8042, ps2_keyboard};
 use device::pic_8259 as pic;
@@ -6,26 +7,14 @@ use device::pit::PIT_TICKS;
 use core::sync::atomic::Ordering;
 use scheduling::{DoesScheduling, SCHEDULER};
 
-#[allow(dead_code)]
-fn trigger(irq: u8) {
-    if irq >= 8 {
-        pic::SLAVE.lock().mask_set(irq - 8);
-        pic::SLAVE.lock().ack();
-    } else {
-        pic::MASTER.lock().mask_set(irq);
-        pic::MASTER.lock().ack();
-    }
-}
-
 pub extern "x86-interrupt" fn timer(_stack_frame: &mut ExceptionStack) {
-    use arch::x86::interrupts;
-
-    pic::MASTER.lock().ack();
-
     //This counter variable is updated every time an timer interrupt occurs. The timer is set to
     //interrupt every 2ms, so this means a reschedule will occur if 20ms have passed.
     if PIT_TICKS.fetch_add(1, Ordering::SeqCst) >= 10 {
         PIT_TICKS.store(0, Ordering::SeqCst);
+
+        // ensure that timer is renabled before entering new process
+        pic::MASTER.lock().ack();
 
         //Find another process to run.
         unsafe {
@@ -33,32 +22,42 @@ pub extern "x86-interrupt" fn timer(_stack_frame: &mut ExceptionStack) {
                 SCHEDULER.resched();
             })
         };
+    } else {
+        pic::MASTER.lock().ack();
     }
 }
 
 pub extern "x86-interrupt" fn keyboard(_stack_frame: &mut ExceptionStack) {
-    // Read a single scancode off our keyboard port.
-    let code = ps2_controller_8042::key_read();
+    interrupts::disable_then_restore(|| {
+        // Read a single scancode off our keyboard port.
+        let code = ps2_controller_8042::key_read();
 
-    // Pass scan code to ps2_keyboard driver
-    ps2_keyboard::parse_key(code);
+        // Pass scan code to ps2_keyboard driver
+        ps2_keyboard::parse_key(code);
 
-    pic::MASTER.lock().ack();
+        pic::MASTER.lock().ack();
+    });
 }
 
 #[allow(unused_variables)]
 pub extern "x86-interrupt" fn cascade(_stack_frame: &mut ExceptionStack) {
-    pic::MASTER.lock().ack();
+    interrupts::disable_then_restore(|| {
+        pic::MASTER.lock().ack();
+    });
 }
 
 pub extern "x86-interrupt" fn com1(_stack_frame: &mut ExceptionStack) {
-    pic::MASTER.lock().ack();
-    let data: u8 = serial::COM1.lock().receive();
-    kprint!("{}", data as char);
+    interrupts::disable_then_restore(|| {
+        pic::MASTER.lock().ack();
+        let data: u8 = serial::COM1.lock().receive();
+        kprint!("{}", data as char);
+    });
 }
 
 pub extern "x86-interrupt" fn com2(_stack_frame: &mut ExceptionStack) {
-    pic::MASTER.lock().ack();
-    let data: u8 = serial::COM2.lock().receive();
-    kprint!("{}", data as char);
+    interrupts::disable_then_restore(|| {
+        pic::MASTER.lock().ack();
+        let data: u8 = serial::COM2.lock().receive();
+        kprint!("{}", data as char);
+    });
 }


### PR DESCRIPTION
Wrap all irq handler code in `disable_then_restore` to avoid deadlocks in the case where an interrupt is fired while `pic::MASTER.lock().ack();` is executing.

Also, let's move the `ack()` for the timer handler so that the timer interrupt is enabled after expensive `PIT_TICKS` calculation is completed.  It'd be more costly to allow interrupts during the check of an atomic because it'd lead to more atomic checks.