### PR TITLE
Refactor console drivers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ before_script:
   - rustup component add rust-src
   - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
   - (test -x $HOME/.cargo/bin/xargo || cargo install xargo)
-  - (test -x $HOME/.cargo/bin/rustup || rustup run nightly cargo install rustfmt-nightly)
+  - (test -x $HOME/.cargo/bin/rustfmt || rustup run nightly cargo install rustfmt-nightly)
   - cargo install-update -a
+  - rustup update
   - rustup component add rustfmt-preview
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rust:
 cache:
   directories:
     - $HOME/.cargo
+    - $HOME/.xargo
+    - $TRAVIS_BUILD_DIR/target
 
 env:
   - ['target=i686']

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ addons:
 
 script:
   - cargo fmt -- --write-mode=diff
-  - make FEATURES="vga serial" RUST_TARGET_PATH=`pwd`
+  - make FEATURES="vga serial"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,8 @@ cache:
     - $HOME/.cargo
 
 env:
-  - ['target=i686', 'FEATURES="vga"']
-  - ['target=i686', 'FEATURES="serial"']
-  - ['target=x86_64', 'FEATURES="vga"']
-  - ['target=x86_64', 'FEATURES="serial"']
+  - ['target=i686']
+  - ['target=x86_64']
 
 before_script:
   - rustup component add rust-src
@@ -25,4 +23,4 @@ addons:
 
 script:
   - cargo fmt -- --write-mode=diff
-  - make RUST_TARGET_PATH=`pwd`
+  - make FEATURES="vga serial" RUST_TARGET_PATH=`pwd`

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ before_script:
   - rustup component add rust-src
   - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
   - (test -x $HOME/.cargo/bin/xargo || cargo install xargo)
-  - rustup run nightly cargo install rustfmt-nightly --force
+  - (test -x $HOME/.cargo/bin/rustup || rustup run nightly cargo install rustfmt-nightly)
   - cargo install-update -a
+  - rustup component add rustfmt-preview
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ before_script:
   - (test -x $HOME/.cargo/bin/xargo || cargo install xargo)
   - (test -x $HOME/.cargo/bin/rustfmt || rustup run nightly cargo install rustfmt-nightly)
   - cargo install-update -a
-  - rustup update
   - rustup component add rustfmt-preview
+  - rustup self update
+  - rustup update
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,8 @@ before_script:
   - rustup component add rust-src
   - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
   - (test -x $HOME/.cargo/bin/xargo || cargo install xargo)
-  - (test -x $HOME/.cargo/bin/rustfmt || rustup run nightly cargo install rustfmt-nightly)
+  - rustup run nightly cargo install rustfmt-nightly --force
   - cargo install-update -a
-  - rustup component add rustfmt-preview
-  - rustup self update
-  - rustup update
 
 addons:
   apt:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["staticlib"]
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 bit_field = "0.7.0"
 bitflags = "1.0.1"
+heapless = "0.2.0"
 linked_list_allocator = "0.4.3"
 multiboot2 = { git = "https://github.com/phil-opp/multiboot2-elf64" }
 once = "0.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["staticlib"]
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 bit_field = "0.7.0"
 bitflags = "1.0.1"
-heapless = "0.2.0"
 linked_list_allocator = "0.4.3"
 multiboot2 = { git = "https://github.com/phil-opp/multiboot2-elf64" }
 once = "0.3.2"

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ ASFLAGS := $(asm_target)
 LDFLAGS := -n --gc-sections -melf_$(ld_target)
 QEMUFLAGS := -nographic
 CARGOFLAGS :=
+PWD := $(shell pwd)
 
 ifdef FEATURES
 	CARGOFLAGS += --no-default-features --features "$(FEATURES)"
@@ -64,7 +65,7 @@ ASM_OBJ := $(patsubst src/arch/$(arch)/asm/%.nasm, build/arch/$(arch)/asm/%.o, $
 all: $(kernel)
 
 cargo:
-	@xargo build --target $(rust_target) $(CARGOFLAGS)
+	@RUST_TARGET_PATH="$(PWD)" xargo build --target $(rust_target) $(CARGOFLAGS)
 
 clean:
 	@cargo clean

--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,8 @@ QEMUFLAGS := -nographic
 CARGOFLAGS :=
 
 ifdef FEATURES
-	CARGOFLAGS += --no-default-features --features $(FEATURES)
-	ifeq ($(FEATURES),vga)
-		QEMUFLAGS :=
-	else ifeq ($(FEATURES), serial)
-		QEMUFLAGS := -nographic
-	endif
+	CARGOFLAGS += --no-default-features --features "$(FEATURES)"
+	QEMUFLAGS :=
 endif
 
 # Rust target

--- a/src/arch/x86/device.rs
+++ b/src/arch/x86/device.rs
@@ -1,8 +1,9 @@
-use device::{pit, pic_8259, ps2_controller_8042, uart_16550};
+use device::{keyboard, pit, pic_8259, ps2_controller_8042, uart_16550};
 
 pub fn init() {
     pic_8259::init();
     uart_16550::init();
     ps2_controller_8042::init();
     pit::init();
+    keyboard::ps2::init();
 }

--- a/src/arch/x86/interrupts/irq.rs
+++ b/src/arch/x86/interrupts/irq.rs
@@ -1,6 +1,5 @@
 use arch::x86::interrupts;
 use arch::x86::interrupts::exception::ExceptionStack;
-use device::{ps2_controller_8042, ps2_keyboard};
 use device::pic_8259 as pic;
 use device::uart_16550 as serial;
 use device::pit::PIT_TICKS;
@@ -29,13 +28,16 @@ pub extern "x86-interrupt" fn timer(_stack_frame: &mut ExceptionStack) {
 
 pub extern "x86-interrupt" fn keyboard(_stack_frame: &mut ExceptionStack) {
     interrupts::disable_then_restore(|| {
+        use device::ps2_controller_8042;
+        use device::keyboard;
+
         pic::MASTER.lock().ack();
 
         // Read a single scancode off our keyboard port.
         let code = ps2_controller_8042::key_read();
 
         // Pass scan code to ps2_keyboard driver
-        ps2_keyboard::parse_key(code);
+        keyboard::ps2::parse_key(code);
     });
 }
 

--- a/src/arch/x86/interrupts/irq.rs
+++ b/src/arch/x86/interrupts/irq.rs
@@ -49,23 +49,13 @@ pub extern "x86-interrupt" fn cascade(_stack_frame: &mut ExceptionStack) {
 pub extern "x86-interrupt" fn com1(_stack_frame: &mut ExceptionStack) {
     interrupts::disable_then_restore(|| {
         pic::MASTER.lock().ack();
-
-        let (bytes, count) = serial::COM1.lock().receive();
-
-        for i in 0..count {
-            kprint!("{}", bytes[i] as char);
-        }
+        serial::COM1.lock().receive();
     });
 }
 
 pub extern "x86-interrupt" fn com2(_stack_frame: &mut ExceptionStack) {
     interrupts::disable_then_restore(|| {
         pic::MASTER.lock().ack();
-
-        let (bytes, count) = serial::COM2.lock().receive();
-
-        for i in 0..count {
-            kprint!("{}", bytes[i] as char);
-        }
+        serial::COM2.lock().receive();
     });
 }

--- a/src/arch/x86/mod.rs
+++ b/src/arch/x86/mod.rs
@@ -12,6 +12,11 @@ pub fn init(multiboot_information_address: usize) {
 
     let mut memory_controller = memory::init(&boot_info);
 
+    unsafe {
+        use self::memory::heap::{HEAP_SIZE, HEAP_START};
+        ::HEAP_ALLOCATOR.init(HEAP_START, HEAP_SIZE);
+    }
+
     gdt::init(&mut memory_controller);
 
     idt::init();

--- a/src/device/keyboard/layout/mod.rs
+++ b/src/device/keyboard/layout/mod.rs
@@ -1,0 +1,1 @@
+pub mod us_std;

--- a/src/device/keyboard/layout/us_std.rs
+++ b/src/device/keyboard/layout/us_std.rs
@@ -1,0 +1,34 @@
+use alloc::Vec;
+
+pub fn map_to_upper(lower: char) -> Vec<char> {
+    if lower.is_alphabetic() {
+        lower.to_uppercase().collect()
+    } else {
+        let upper = match lower {
+            '`' => '~',
+            '1' => '!',
+            '2' => '@',
+            '3' => '#',
+            '4' => '$',
+            '5' => '%',
+            '6' => '^',
+            '7' => '&',
+            '8' => '*',
+            '9' => '(',
+            '0' => ')',
+            '-' => '_',
+            '=' => '+',
+            '[' => '{',
+            ']' => '}',
+            '\\' => '|',
+            ';' => ':',
+            '\'' => '"',
+            ',' => '<',
+            '.' => '>',
+            '/' => '?',
+            _ => 0x0 as char
+        };
+
+        vec![upper]
+    }
+}

--- a/src/device/keyboard/layout/us_std.rs
+++ b/src/device/keyboard/layout/us_std.rs
@@ -1,34 +1,30 @@
-use alloc::Vec;
-
-pub fn map_to_upper(lower: char) -> Vec<char> {
-    if lower.is_alphabetic() {
-        lower.to_uppercase().collect()
+pub fn map_to_upper(lower: u8) -> u8 {
+    if lower.is_ascii_lowercase() {
+        lower.to_ascii_uppercase()
     } else {
-        let upper = match lower {
-            '`' => '~',
-            '1' => '!',
-            '2' => '@',
-            '3' => '#',
-            '4' => '$',
-            '5' => '%',
-            '6' => '^',
-            '7' => '&',
-            '8' => '*',
-            '9' => '(',
-            '0' => ')',
-            '-' => '_',
-            '=' => '+',
-            '[' => '{',
-            ']' => '}',
-            '\\' => '|',
-            ';' => ':',
-            '\'' => '"',
-            ',' => '<',
-            '.' => '>',
-            '/' => '?',
-            _ => 0x0 as char
-        };
-
-        vec![upper]
+        match lower {
+            b'`' => b'~',
+            b'1' => b'!',
+            b'2' => b'@',
+            b'3' => b'#',
+            b'4' => b'$',
+            b'5' => b'%',
+            b'6' => b'^',
+            b'7' => b'&',
+            b'8' => b'*',
+            b'9' => b'(',
+            b'0' => b')',
+            b'-' => b'_',
+            b'=' => b'+',
+            b'[' => b'{',
+            b']' => b'}',
+            b'\\' => b'|',
+            b';' => b':',
+            b'\'' => b'"',
+            b',' => b'<',
+            b'.' => b'>',
+            b'/' => b'?',
+            _ => 0x0,
+        }
     }
 }

--- a/src/device/keyboard/mod.rs
+++ b/src/device/keyboard/mod.rs
@@ -1,12 +1,11 @@
-use alloc::string::{String, ToString};
 use spin::Mutex;
 
 macro_rules! key_press {
-        ($x:expr) => (Some(KeyEvent::Pressed($x)))
+    ($x:expr) => (Some(KeyEvent::Pressed($x)))
 }
 
 macro_rules! key_release {
-        ($x:expr) => (Some(KeyEvent::Released($x)))
+    ($x:expr) => (Some(KeyEvent::Released($x)))
 }
 
 pub mod layout;
@@ -73,12 +72,12 @@ impl ModifierState {
     }
 
     /// Apply all of our modifiers to character and convert to String
-    pub fn apply_to(&self, ascii: char) -> String {
+    pub fn apply_to(&self, ascii: u8) -> u8 {
         if self.is_uppercase() {
             use self::layout;
-            layout::us_std::map_to_upper(ascii).iter().collect()
+            layout::us_std::map_to_upper(ascii)
         } else {
-            ascii.to_string()
+            ascii
         }
     }
 

--- a/src/device/keyboard/mod.rs
+++ b/src/device/keyboard/mod.rs
@@ -9,6 +9,11 @@ macro_rules! key_release {
         ($x:expr) => (Some(KeyEvent::Released($x)))
 }
 
+pub mod layout;
+pub mod ps2;
+
+pub static STATE: Mutex<ModifierState> = Mutex::new(ModifierState::new());
+
 #[derive(Debug)]
 struct KeyPair {
     left: bool,
@@ -67,11 +72,11 @@ impl ModifierState {
         self.shift.is_pressed() ^ self.caps_lock
     }
 
-    /// Apply all of our modifiers to an ASCII character, and return a new
-    /// ASCII character.
+    /// Apply all of our modifiers to character and convert to String
     pub fn apply_to(&self, ascii: char) -> String {
         if self.is_uppercase() {
-            ascii.to_uppercase().collect()
+            use self::layout;
+            layout::us_std::map_to_upper(ascii).iter().collect()
         } else {
             ascii.to_string()
         }
@@ -104,7 +109,3 @@ pub enum Key {
     Meta(Modifier),
     LowerAscii(u8),
 }
-
-pub static STATE: Mutex<ModifierState> = Mutex::new(ModifierState::new());
-
-pub mod ps2;

--- a/src/device/keyboard/ps2.rs
+++ b/src/device/keyboard/ps2.rs
@@ -72,9 +72,7 @@ pub struct Ps2 {
 
 impl Ps2 {
     pub const fn new() -> Ps2 {
-        Ps2 {
-            buffer: None,
-        }
+        Ps2 { buffer: None }
     }
 
     fn init(&mut self) {

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -6,3 +6,18 @@ pub mod pit;
 pub mod ps2_controller_8042;
 pub mod uart_16550;
 pub mod vga;
+
+use alloc::VecDeque;
+
+pub trait BufferedDevice {
+    fn buffer(&self) -> &VecDeque<u8>;
+    fn buffer_mut(&mut self) -> &mut VecDeque<u8>;
+}
+
+pub trait InputDevice {
+    fn read(&mut self, num_bytes: usize) -> VecDeque<char>;
+}
+
+pub trait OutputDevice {
+    fn write(&mut self, data: VecDeque<char>);
+}

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1,7 +1,8 @@
 #[macro_use]
 pub mod keyboard;
+
 pub mod pic_8259;
+pub mod pit;
 pub mod ps2_controller_8042;
 pub mod uart_16550;
 pub mod vga;
-pub mod pit;

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1,6 +1,6 @@
+#[macro_use]
 pub mod keyboard;
 pub mod pic_8259;
-pub mod ps2_keyboard;
 pub mod ps2_controller_8042;
 pub mod uart_16550;
 pub mod vga;

--- a/src/device/uart_16550.rs
+++ b/src/device/uart_16550.rs
@@ -58,9 +58,9 @@ pub fn read(len: usize) {
 }
 
 fn get_fifo_ctrl_byte() -> u8 {
-    let mut byte = 1 << 0;  // enable FIFO
-    byte |= 1 << 1;         // clear Receive FIFO
-    byte |= 1 << 2;         // clear Transmit FIFO
+    let mut byte = 1 << 0; // enable FIFO
+    byte |= 1 << 1; // clear Receive FIFO
+    byte |= 1 << 2; // clear Transmit FIFO
 
     // bits 6-7 represent num bytes in interrupt trigger
     byte |= match FIFO_BYTE_THRESHOLD {
@@ -117,18 +117,18 @@ impl<T: Io<Value = u8>> SerialPort<T> {
     }
 
     pub fn init(&mut self) {
-        self.int_en.write(0x00);          // disable interrupts
-        self.line_ctrl.write(0x80);       // enable DLAB (set baud rate divisor)
-        self.data.write(0x03);            // set divisor to 3 (lo byte) 38400 baud
-        self.int_en.write(0x00);          // (hi byte)
-        self.line_ctrl.write(0x03);       // 8 bits, no parity, one stop bit
+        self.int_en.write(0x00); // disable interrupts
+        self.line_ctrl.write(0x80); // enable DLAB (set baud rate divisor)
+        self.data.write(0x03); // set divisor to 3 (lo byte) 38400 baud
+        self.int_en.write(0x00); // (hi byte)
+        self.line_ctrl.write(0x03); // 8 bits, no parity, one stop bit
 
         // 16550 specific FIFO Control Register
         let fifo_byte = get_fifo_ctrl_byte();
         self.fifo_ctrl.write(fifo_byte);
 
-        self.modem_ctrl.write(0x0B);      // IRQs enabled, RTS/DSR set
-        self.int_en.write(0x01);          // enable interrupts
+        self.modem_ctrl.write(0x0B); // IRQs enabled, RTS/DSR set
+        self.int_en.write(0x01); // enable interrupts
     }
 
     fn line_sts(&self) -> LineStsFlags {

--- a/src/device/uart_16550.rs
+++ b/src/device/uart_16550.rs
@@ -11,8 +11,8 @@ pub static COM1: Mutex<SerialPort<Port<u8>>> =
 pub static COM2: Mutex<SerialPort<Port<u8>>> =
     Mutex::new(SerialPort::<Port<u8>>::new(SERIAL_PORT2));
 
-// TODO: Replace arbitrary value for clearing rows
 pub const BUF_LEN: usize = 1024;
+// TODO: Replace arbitrary value for clearing rows
 const BUF_MAX_HEIGHT: usize = 25;
 const FIFO_BYTE_THRESHOLD: usize = 14;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@ extern crate once;
 
 extern crate bit_field;
 extern crate compiler_builtins;
-extern crate heapless;
 extern crate linked_list_allocator;
 extern crate multiboot2;
 extern crate rlibc;
@@ -48,12 +47,9 @@ pub extern "C" fn rust_main(multiboot_information_address: usize) {
     arch::interrupts::disable();
     {
         arch::init(multiboot_information_address);
-        kprintln!("\nIt did not crash!");
 
-        unsafe {
-            HEAP_ALLOCATOR.init(HEAP_START, HEAP_SIZE);
-        }
-    }
+        kprintln!("\nIt did not crash!");
+   }
     arch::interrupts::enable();
 
     kprintln!("\nHEAP START = 0x{:x}", HEAP_START);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub extern "C" fn rust_main(multiboot_information_address: usize) {
         arch::init(multiboot_information_address);
 
         kprintln!("\nIt did not crash!");
-   }
+    }
     arch::interrupts::enable();
 
     kprintln!("\nHEAP START = 0x{:x}", HEAP_START);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ extern crate once;
 
 extern crate bit_field;
 extern crate compiler_builtins;
+extern crate heapless;
 extern crate linked_list_allocator;
 extern crate multiboot2;
 extern crate rlibc;
@@ -58,14 +59,13 @@ pub extern "C" fn rust_main(multiboot_information_address: usize) {
     kprintln!("\nHEAP START = 0x{:x}", HEAP_START);
     kprintln!("HEAP END = 0x{:x}\n", HEAP_START + HEAP_SIZE);
 
-    let max_procs = 50;
-    for i in 0..max_procs {
-        syscall::create(test_process, format!("test_process_{}", i));
-    }
-
     syscall::create(rxinu_main, String::from("rxinu_main"));
 
-    loop {}
+    loop {
+        // Continue reading and printing from uart buffer
+        use device::uart_16550 as uart;
+        uart::read(uart::BUF_LEN);
+    }
 }
 
 /// Main initialization process for rxinu

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,9 +58,16 @@ pub extern "C" fn rust_main(multiboot_information_address: usize) {
     syscall::create(rxinu_main, String::from("rxinu_main"));
 
     loop {
-        // Continue reading and printing from uart buffer
-        use device::uart_16550 as uart;
-        uart::read(uart::BUF_LEN);
+        #[cfg(feature = "serial")]
+        {
+            use device::uart_16550 as uart;
+            uart::read(1024);
+        }
+        #[cfg(feature = "vga")]
+        {
+            use device::keyboard::ps2 as kbd;
+            kbd::read(1024);
+        }
     }
 }
 


### PR DESCRIPTION
## Major Changes

### Multiple console outputs

Specifying `make FEATURES = "vga serial"` allows for printing to both `VGA` and `COM1`.

We also add this to `.travis.yml` to combine the Travis builds into two total builds.

### Receive bytes into input buffer

Fixes #21 

This more closely aligns our UART driver with the UART driver in `xinu`.  Instead of printing all data available in the UART data register, we add the characters into an input buffer that can be read later.  For example, they can be read from a shell program.

### ~~Use rustfmt component in Travis~~

~~By using rustup `rustfmt-nightly` component, we can save time in Travis builds.~~

Getting the `rustfmt-preview` component added in the Travis build was inconsistent.  A separate PR should be used for this update.

### Makefile sets `RUST_TARGET_PATH` environment variable

Fixes #45 

### Refactor Keyboard code

* [x] Part 1: Re-organize code so that it makes sense
* [x] Part 2: Resolve #24 
* [x] Part 3: Utilize buffer for PS/2 driver
~~Part 4: [TTY support](http://wiki.osdev.org/Kernel_Stdio_Theory)~~  This isn't needed for now. Save this work for later.
  