### PR TITLE
Update to latest rust nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 bit_field = "0.7.0"
 bitflags = "1.0.1"
-linked_list_allocator = "0.6.0"
+linked_list_allocator = { git = "https://github.com/dancrossnyc/linked-list-allocator" }
 once = "0.3.2"
 os_bootinfo = "0.2.0"
 rlibc = "1.0.0"
 spin = "0.4.6"
 volatile = "0.1.0"
-x86_64 = "0.2.0-alpha-019"
+x86_64 = { git = "https://github.com/robert-w-gries/x86_64", branch = "frame_alloc_fix" }
 
 [dependencies.lazy_static]
 version = "0.2.4"

--- a/src/arch/x86_64/memory/area_frame_allocator.rs
+++ b/src/arch/x86_64/memory/area_frame_allocator.rs
@@ -1,6 +1,7 @@
-use arch::x86_64::memory::FrameAllocator;
 use os_bootinfo::{FrameRange, MemoryMap, MemoryRegionType};
-use x86_64::structures::paging::{PhysFrame, PhysFrameRange, Size4KiB};
+use x86_64::structures::paging::{
+    FrameAllocator, FrameDeallocator, PhysFrame, PhysFrameRange, Size4KiB,
+};
 
 pub struct AreaFrameAllocator {
     memory_map: MemoryMap,
@@ -17,8 +18,8 @@ impl AreaFrameAllocator {
     }
 }
 
-impl FrameAllocator for AreaFrameAllocator {
-    fn allocate_frame(&mut self) -> Option<PhysFrame> {
+impl FrameAllocator<Size4KiB> for AreaFrameAllocator {
+    fn alloc(&mut self) -> Option<PhysFrame<Size4KiB>> {
         let region = &mut self
             .memory_map
             .iter_mut()
@@ -40,9 +41,11 @@ impl FrameAllocator for AreaFrameAllocator {
             None
         }
     }
+}
 
+impl FrameDeallocator<Size4KiB> for AreaFrameAllocator {
     #[allow(unused)]
-    fn deallocate_frame(&mut self, frame: PhysFrame) {
+    fn dealloc(&mut self, frame: PhysFrame<Size4KiB>) {
         unimplemented!()
     }
 }

--- a/src/arch/x86_64/memory/heap/mod.rs
+++ b/src/arch/x86_64/memory/heap/mod.rs
@@ -1,7 +1,7 @@
 /// Use allocator wrapper, similar to what le-jzr/sisyphos-kernel-uefi-x86_64 uses
 pub mod bump_allocator;
 
-use core::alloc::{Alloc, GlobalAlloc, Layout, Opaque};
+use core::alloc::{Alloc, GlobalAlloc, Layout};
 use core::ptr::NonNull;
 use linked_list_allocator::Heap;
 use sync::IrqLock;
@@ -34,16 +34,16 @@ impl HeapAllocator {
 
 /// Wrappers for inner Alloc implementation
 unsafe impl GlobalAlloc for HeapAllocator {
-    unsafe fn alloc(&self, layout: Layout) -> *mut Opaque {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         self.inner
             .lock()
             .alloc(layout)
             .ok()
-            .map_or(0 as *mut Opaque, |allocation| allocation.as_ptr())
+            .map_or(0 as *mut u8, |allocation| allocation.as_ptr())
     }
 
     #[inline]
-    unsafe fn dealloc(&self, ptr: *mut Opaque, layout: Layout) {
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         self.inner
             .lock()
             .dealloc(NonNull::new_unchecked(ptr), layout);

--- a/src/arch/x86_64/memory/stack_allocator.rs
+++ b/src/arch/x86_64/memory/stack_allocator.rs
@@ -1,6 +1,7 @@
-use arch::x86_64::memory::{map_page, FrameAllocator};
+use arch::x86_64::memory::map_page;
 use x86_64::structures::paging::{
-    Page, PageRangeInclusive, PageSize, PageTableFlags, RecursivePageTable, Size4KiB,
+    FrameAllocator, Page, PageRangeInclusive, PageSize, PageTableFlags, RecursivePageTable,
+    Size4KiB,
 };
 
 pub struct StackAllocator {
@@ -14,7 +15,7 @@ impl StackAllocator {
 }
 
 impl StackAllocator {
-    pub fn alloc_stack<FA: FrameAllocator>(
+    pub fn alloc_stack<FA: FrameAllocator<Size4KiB>>(
         &mut self,
         page_table: &mut RecursivePageTable,
         frame_allocator: &mut FA,


### PR DESCRIPTION
Resolves compilation errors after allocator stabilization PR went through.

Also, temporarily point to git branches that work on latest rust nightly