### PR TITLE
Change from deprecated panic_implementation to panic_handler

### DIFF
--- a/src/bin/test-basic-boot.rs
+++ b/src/bin/test-basic-boot.rs
@@ -1,4 +1,4 @@
-#![feature(panic_implementation)] // required for defining the panic handler
+#![feature(panic_handler)] // required for defining the panic handler
 #![feature(const_fn)]
 #![no_std] // don't link the Rust standard library
 #![cfg_attr(not(test), no_main)] // disable all Rust-level entry points
@@ -26,7 +26,7 @@ pub extern "C" fn _start() -> ! {
 
 /// This function is called on panic.
 #[cfg(not(test))]
-#[panic_implementation]
+#[panic_handler]
 #[no_mangle]
 pub fn panic(info: &PanicInfo) -> ! {
     serial_println!("failed");

--- a/src/bin/test-exception-breakpoint.rs
+++ b/src/bin/test-exception-breakpoint.rs
@@ -1,4 +1,4 @@
-#![feature(panic_implementation)]
+#![feature(panic_handler)]
 #![feature(abi_x86_interrupt)]
 #![no_std]
 #![cfg_attr(not(test), no_main)]
@@ -45,7 +45,7 @@ pub extern "C" fn _start() -> ! {
 
 /// This function is called on panic.
 #[cfg(not(test))]
-#[panic_implementation]
+#[panic_handler]
 #[no_mangle]
 pub fn panic(info: &PanicInfo) -> ! {
     serial_println!("failed");

--- a/src/bin/test-exception-stack-overflow.rs
+++ b/src/bin/test-exception-stack-overflow.rs
@@ -1,4 +1,4 @@
-#![feature(panic_implementation)]
+#![feature(panic_handler)]
 #![feature(abi_x86_interrupt)]
 #![no_std]
 #![cfg_attr(not(test), no_main)]
@@ -42,7 +42,7 @@ pub extern "C" fn _start() -> ! {
 
 /// This function is called on panic.
 #[cfg(not(test))]
-#[panic_implementation]
+#[panic_handler]
 #[no_mangle]
 pub fn panic(info: &PanicInfo) -> ! {
     serial_println!("failed");

--- a/src/bin/test-panic.rs
+++ b/src/bin/test-panic.rs
@@ -1,4 +1,4 @@
-#![feature(panic_implementation)]
+#![feature(panic_handler)]
 #![feature(const_fn)]
 #![no_std]
 #![cfg_attr(not(test), no_main)]
@@ -17,7 +17,7 @@ pub extern "C" fn _start() -> ! {
 }
 
 #[cfg(not(test))]
-#[panic_implementation]
+#[panic_handler]
 #[no_mangle]
 pub fn panic(_info: &PanicInfo) -> ! {
     serial_println!("ok");

--- a/src/bin/test-task-basic-process.rs
+++ b/src/bin/test-task-basic-process.rs
@@ -1,4 +1,4 @@
-#![feature(alloc, panic_implementation)] // required for defining the panic handler
+#![feature(alloc, panic_handler)] // required for defining the panic handler
 #![feature(const_fn)]
 #![no_std] // don't link the Rust standard library
 #![cfg_attr(not(test), no_main)] // disable all Rust-level entry points
@@ -49,7 +49,7 @@ pub extern "C" fn test_process() {
 
 /// This function is called on panic.
 #[cfg(not(test))]
-#[panic_implementation]
+#[panic_handler]
 #[no_mangle]
 pub fn panic(info: &PanicInfo) -> ! {
     serial_println!("failed");

--- a/src/bin/test-task-ipc.rs
+++ b/src/bin/test-task-ipc.rs
@@ -1,4 +1,4 @@
-#![feature(alloc, panic_implementation)]
+#![feature(alloc, panic_handler)]
 #![feature(const_fn)]
 #![no_std]
 #![cfg_attr(not(test), no_main)]
@@ -66,7 +66,7 @@ pub extern "C" fn loop_process() {
 }
 
 #[cfg(not(test))]
-#[panic_implementation]
+#[panic_handler]
 #[no_mangle]
 pub fn panic(info: &PanicInfo) -> ! {
     serial_println!("failed");

--- a/src/bin/test-task-preemption.rs
+++ b/src/bin/test-task-preemption.rs
@@ -1,4 +1,4 @@
-#![feature(alloc, panic_implementation)]
+#![feature(alloc, panic_handler)]
 #![feature(const_fn)]
 #![no_std]
 #![cfg_attr(not(test), no_main)]
@@ -50,7 +50,7 @@ pub extern "C" fn loop_process() {
 }
 
 #[cfg(not(test))]
-#[panic_implementation]
+#[panic_handler]
 #[no_mangle]
 pub fn panic(info: &PanicInfo) -> ! {
     unsafe {

--- a/src/bin/test-task-syscall.rs
+++ b/src/bin/test-task-syscall.rs
@@ -1,4 +1,4 @@
-#![feature(alloc, panic_implementation)] // required for defining the panic handler
+#![feature(alloc, panic_handler)] // required for defining the panic handler
 #![feature(const_fn)]
 #![no_std] // don't link the Rust standard library
 #![cfg_attr(not(test), no_main)] // disable all Rust-level entry points
@@ -93,7 +93,7 @@ pub extern "C" fn suspend_process() {
 }
 
 #[cfg(not(test))]
-#[panic_implementation]
+#[panic_handler]
 #[no_mangle]
 pub fn panic(info: &PanicInfo) -> ! {
     serial_println!("failed");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(alloc, alloc_error_handler, lang_items, panic_implementation)]
+#![feature(alloc, alloc_error_handler, lang_items, panic_handler)]
 #![no_std]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(test, allow(dead_code, unused_macros, unused_imports))]
@@ -48,7 +48,7 @@ pub extern "C" fn _start(boot_info_address: usize) -> ! {
 }
 
 #[cfg(not(test))]
-#[panic_implementation]
+#[panic_handler]
 #[no_mangle]
 pub fn panic(info: &PanicInfo) -> ! {
     kprintln!("{}", info);


### PR DESCRIPTION
Addresses the following warning:

```
warning: use of deprecated attribute `panic_implementation`: This attribute was renamed to `panic_handler`. See https://github.com/rust-lang/rust/issues/44489#issuecomment-415140224
  --> src/bin/test-task-basic-process.rs:52:1
   |
52 | #[panic_implementation]
   | ^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
   |
   = note: #[warn(deprecated)] on by default
```